### PR TITLE
Remove template tag library future

### DIFF
--- a/oscar_rosetta/templates/rosetta/pofile.html
+++ b/oscar_rosetta/templates/rosetta/pofile.html
@@ -1,6 +1,5 @@
 {% extends "rosetta/base.html" %}{% load admin_static %}
 {% load rosetta i18n %}
-{% load url from future %}
 
 {% block extrastyles %}
 <style type="text/css" media="screen"> {% include 'rosetta/static/css/styles.css' %} </style>


### PR DESCRIPTION
Template tag library future does not exist on Django 2.

Closes https://github.com/scaryclam/django-oscar-rosetta/issues/5